### PR TITLE
docs: align platform READMEs with the current build and runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,18 @@ Documentation highlights:
 
 ![Application Architecture](https://raw.githubusercontent.com/netuno-org/platform/main/docs/images/app-architecture.png)
 
-Netuno is written in Java and runs in GraalVM to facilitate web application development, it currently suppports the following programming languages:
+Netuno is written in Java and runs in GraalVM to facilitate web application development. It currently supports the following programming languages:
 
-- [JavaScript/ES6](https://www.graalvm.org/javascript/)
-- [Groovy](https://groovy-lang.org)
+- [JavaScript/ES6 and TypeScript](https://www.graalvm.org/javascript/)
+- [Groovy](https://groovy.apache.org/)
 - [JRuby (Ruby)](https://www.jruby.org)
-- [Jython (Python)](https://www.jython.org)
+- [GraalPy (Python)](https://www.graalvm.org/python/)
 - [Kotlin](https://kotlinlang.org)
+- CajuScript
 
 > 😎 While you are programming you won't need to restart the server to compile the newly updated code.
 >
-> All log outputs such as server-side, client-side (NPM `run watch`) and other outputs are integrated in the same console. By having this feature you'll only need to look to one console thus easing your work.
+> All log outputs, such as server-side, client-side (`pnpm run watch`), and other command outputs, are integrated in the same console. This means you only need to monitor one console while developing.
 
 ## Build Requirements
 
@@ -66,7 +67,7 @@ Continue with the steps below if you want to compile from scratch and contribute
 
 Make sure to use the GraalVM JDK as your Java environment:
 
-- [GraalVM with Java 25](https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-25.0.2)
+- [GraalVM with Java 25](https://www.graalvm.org/downloads/)
 
 ## Linux or Mac
 
@@ -104,7 +105,7 @@ After installation and following the steps indicated by the script, run option 1
 
 If you see the error:
 
-```java.lang.NoClassDefFoundError: io/github/classgraph/ClassGraph```
+   `java.lang.NoClassDefFoundError: io/github/classgraph/ClassGraph`
 
 It means the **ClassGraph** library is missing.
 
@@ -116,7 +117,7 @@ It means the **ClassGraph** library is missing.
 
 2. **Install the library**  
    Place the downloaded `.jar` in:  
-   ```.\bundle\base\web\WEB-INF\lib```
+   `.\bundle\base\core\web\WEB-INF\lib`
 
 ## Bundle
 
@@ -149,12 +150,12 @@ The published Netuno version will be generated in `bundle/dist/netuno*`, which i
 
 ## Build
 
-The build script executes the Maven phases: clean and package.
+The build script executes the Maven phases `clean`, `compile`, and `package`.
 
 ### Windows Commands
 
-```sh
- $ ./build.ps1
+```ps1
+ $ .\build.ps1
 ```
 
 ### Linux or Mac Commands

--- a/bundle/README.md
+++ b/bundle/README.md
@@ -1,3 +1,3 @@
 # Netuno Bundle
 
-Netuno platform bundle generate.
+Scripts and base assets used to generate Netuno Platform distribution bundles.

--- a/bundle/base/README.md
+++ b/bundle/base/README.md
@@ -2,7 +2,7 @@
 
 Quickly build applications adapted to your business logic.
 
-More about Netuno in [netuno.org](https://www.netuno.org/) and learn how tu use it in [doc.netuno.org](https://doc.netuno.org/).
+Learn more about Netuno at [netuno.org](https://www.netuno.org/) and how to use it at [doc.netuno.org](https://doc.netuno.org/).
 
 Feel free to use and please report any [issues](https://github.com/netuno-org/platform/issues) you may find.
 
@@ -42,7 +42,7 @@ To start the server, by default it'll use the demo application:
 ./netuno server
 ```
 
-To start the server with a specific application in the following example you shoukd replace the app value (my_app_name) by the name of the app you want to launch:
+To start the server with a specific application, replace the `app` value (`my_app_name` in this example) with the name of the app you want to launch:
 
 ```
 ./netuno server app=my_app_name

--- a/bundle/base/apps/_/README.md
+++ b/bundle/base/apps/_/README.md
@@ -1,0 +1,16 @@
+# Application Template (`_`)
+
+This directory (`_`) serves as the core skeleton/template for new applications created within the Netuno platform.
+
+When you use the Netuno CLI to create a new application (`./netuno app`), this directory structure is copied to serve as the foundation of your new app.
+
+## Structure Overview
+
+* **`config/`**: Contains the environment-specific configuration files (`.json` and `.js`).
+* **`server/`**: The backend of your application. Contains REST services, core logic, setup scripts, and templates written in one of the polyglot supported languages (JavaScript, TypeScript, Python, Ruby, Kotlin, Groovy, CajuScript).
+* **`ui/`**: The user interface dashboard build environment (React, Ant Design, Vite).
+* **`public/`**: Publicly accessible assets and files.
+* **`storage/`**: Directory used for persistent file storage (e.g., uploads).
+* **`dbs/`**: Local file-based database configurations (if applicable).
+
+To learn more about each specific section, check the `README.md` inside the respective directories.

--- a/bundle/base/apps/_/server/README.md
+++ b/bundle/base/apps/_/server/README.md
@@ -6,13 +6,15 @@ The polyglot scripting framework makes the REST API development easy and fast.
 
 The supported languages with their code file extensions are:
 
-- JavaScript`.js`
-- Python`.py`
-- Ruby`.rb`
-- Kotlin`.kts`
-- Groovy`.groovy`
+- JavaScript: `.js`, `.cjs`, `.mjs`
+- TypeScript: `.ts`
+- Python (GraalPy): `.py`
+- Ruby (JRuby): `.rb`
+- Kotlin: `.kts`
+- Groovy: `.groovy`
+- CajuScript: `.cj`
 
-The backend folders and their purpose are:
+The backend folders and their purpose are listed below. A new application ships with `core`, `services`, `setup`, and `templates`; the others (`actions`, `components`, `reports`) are optional and can be created when you need them.
 
 - `actions` - Injects code behavior in form and database modifications, more about [Actions](https://doc.netuno.org/docs/academy/server/actions).
 - `components` - Custom form fields and data structures.

--- a/bundle/base/apps/_/ui/README.md
+++ b/bundle/base/apps/_/ui/README.md
@@ -5,22 +5,22 @@ Welcome to the User Interface development of the Netuno Platform.
 
 Here you can build your dashboards and additional functionalities.
 
-This default setup is based on React and Ant.Design, Vite, Bun, and PNPM.
+This default setup is based on React, Ant Design, Vite, and PNPM.
 
 You are free to change, remove, or replace any default technology as you want.
 
 ### Default Requisites
 
-Bun is required on the system as default.
+PNPM is required by the default development command generated in the application's `_development.json` configuration.
 
-- [**Bun Installation**](https://bun.sh/docs/installation)
+- [**PNPM Installation**](https://pnpm.io/installation)
 
-[More about Bun.](https://doc.netuno.org/docs/academy/website/bun/)
+[More about the UI development workflow.](https://doc.netuno.org/docs/academy/website/create/)
 
 ### Install Packages
 
-`bun install`
+`pnpm install`
 
 ### Watch changes and auto recompile
 
-`bun run watch`
+`pnpm run watch`

--- a/bundle/base/apps/demo/README.md
+++ b/bundle/base/apps/demo/README.md
@@ -1,0 +1,16 @@
+# Demo Application
+
+This is the `demo` application that comes pre-installed with the Netuno Platform bundle.
+
+It provides a practical, working example of how a Netuno application is structured and functions. It acts as both a tutorial reference and a ready-to-test sandbox.
+
+## Structure Overview
+
+* **`config/`**: Contains the environment-specific configuration files (`.json` and `.js`) tailored for the demo.
+* **`server/`**: The backend of the demo app, demonstrating REST services, database setup, and templating.
+* **`ui/`**: The React-based dashboard showcasing data presentation and interaction.
+* **`public/`**: Public assets and entry points.
+* **`storage/`**: Local storage used by the demo forms and file uploads.
+* **`dbs/`**: Database configuration defaults for the demo.
+
+By default, when you start the Netuno server without specifying an app parameter (`./netuno server`), this `demo` application is loaded automatically.

--- a/bundle/base/apps/demo/ui/README.md
+++ b/bundle/base/apps/demo/ui/README.md
@@ -1,8 +1,8 @@
 
 ### Install Packages
 
-`bun install`
+`pnpm install`
 
 ### Watch changes and auto recompile
 
-`bun run watch`
+`pnpm run watch`

--- a/docs/IntelliJ-IDEA.md
+++ b/docs/IntelliJ-IDEA.md
@@ -34,7 +34,7 @@ Configure the fields like this:
 <img src="https://raw.githubusercontent.com/netuno-org/platform/main/docs/images/intellij-idea/run-debug-configurations.png" width="525"/>
 
 Make sure of:
-- [GraalVM with Java 25](https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-25.0.2)
+- [GraalVM with Java 25](https://www.graalvm.org/downloads/)
 - Module is `netuno-cli`
 - Main class is `org.netuno.cli.Main`
 - Working directory is `bundle/base`

--- a/netuno.cli/README.md
+++ b/netuno.cli/README.md
@@ -1,5 +1,5 @@
 # Netuno CLI
 
-Command-line interface of the Netuno using [picocli](https://picocli.info/).
+Netuno's command-line interface, implemented with [picocli](https://picocli.info/).
 
-Server launch implementation possible with [Jetty](https://www.eclipse.org/jetty/); Platform installation with [GraalVM](https://www.graalvm.org/); Application creation, monitoring and CRON Jobs with [Quartz Scheduler](http://www.quartz-scheduler.org/) and others.
+It launches the server with [Jetty](https://www.eclipse.org/jetty/), installs the platform with [GraalVM](https://www.graalvm.org/), and manages application creation, monitoring, and CRON jobs with [Quartz Scheduler](https://www.quartz-scheduler.org/), among other features.

--- a/netuno.cli/load-test/README.md
+++ b/netuno.cli/load-test/README.md
@@ -13,7 +13,11 @@ Useful for using with VisualVM to find leaks.
 
 ### POST
 
-Parameters are loaded in `post.json`.
+The request body is loaded from `post.json`. Create that file in this directory before running the script; for example:
+
+```json
+{}
+```
 
 ```
 ./post.sh http://localhost:9000/services/my-service

--- a/netuno.library.doc/README.md
+++ b/netuno.library.doc/README.md
@@ -1,4 +1,4 @@
 
 # Library Doc
 
-Java annotations to manage the generation of the Netuno documentation, such as ressource.
+Java annotations used to generate Netuno library resource documentation.

--- a/netuno.tritao/README.md
+++ b/netuno.tritao/README.md
@@ -15,11 +15,12 @@ Databases supported:
 ### Languages
 
 Polyglot script execution support:
-- [JavaScript/ES6](https://www.graalvm.org/javascript/)
-- [Groovy](https://groovy-lang.org)
+- [JavaScript/ES6 and TypeScript](https://www.graalvm.org/javascript/)
+- [Groovy](https://groovy.apache.org/)
 - [JRuby (Ruby)](https://www.jruby.org)
-- [Jython (Python)](https://www.jython.org)
+- [GraalPy (Python)](https://www.graalvm.org/python/)
 - [Kotlin](https://kotlinlang.org)
+- CajuScript
 
 ### Resources Low-Code
 
@@ -37,4 +38,4 @@ Many programming resources supported, some to low-code integration with:
 - Database
 - Performance Monitor
 
-> Find more and detailed information in the [library documentation](https://doc.netuno.org/docs/en/library/overview/).
+> Find more detailed information in the [library documentation](https://doc.netuno.org/docs/library/overview/).


### PR DESCRIPTION
## What

Aligns the platform READMEs with the current code, build scripts, and configuration.

- **Supported languages:** update to the registered `@ScriptSandbox` extensions — JavaScript (`.js`/`.cjs`/`.mjs`), TypeScript (`.ts`), GraalPy (`.py`), JRuby (`.rb`), Kotlin (`.kts`), Groovy (`.groovy`), CajuScript (`.cj`) — and remove Jython. Verified against the `@ScriptSandbox(extensions = {...})` annotations in `netuno.tritao/.../sandbox/`.
- **Build:** describe the Maven phases actually run by `build.sh` / `build.ps1` (`clean`, `compile`, `package`) and use PowerShell syntax for the Windows call.
- **ClassGraph fix:** correct the generated lib path to `bundle/base/core/web/WEB-INF/lib` (the previous `bundle/base/web/WEB-INF/lib` does not exist).
- **UI template:** keep PNPM — `netuno.cli/.../App.java` generates `pnpm install` / `pnpm run watch` for generated apps.
- **App template:** clarify that a new app ships `core`, `services`, `setup`, `templates`, and that `actions`, `components`, `reports` are optional.
- **New:** `README.md` for `bundle/base/apps/_` (the app template) and `bundle/base/apps/demo`.

Documentation only.