### PR TITLE
Build phases and ClassGraph library path corrected in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ It means the **ClassGraph** library is missing.
 
 2. **Install the library**  
    Place the downloaded `.jar` in:  
-   ```.\bundle\base\web\WEB-INF\lib```
+   ```.\bundle\base\core\web\WEB-INF\lib```
 
 ## Bundle
 
@@ -149,7 +149,7 @@ The published Netuno version will be generated in `bundle/dist/netuno*`, which i
 
 ## Build
 
-The build script executes the Maven phases: clean and package.
+The build script executes the Maven phases `clean`, `compile`, and `package`.
 
 ### Windows Commands
 


### PR DESCRIPTION
## What

Two corrections in the top-level `README.md`:

- The build script runs three Maven phases — `clean`, `compile`, `package` — not just clean and package.
- The ClassGraph `.jar` goes in `bundle/base/core/web/WEB-INF/lib`. The documented `bundle/base/web/WEB-INF/lib` path does not exist (the README's own "Bundle" section already refers to `bundle/base/core/web/WEB-INF/lib`).

## How to verify

    cat build.sh                          # mvn clean; mvn compile; mvn package
    ls bundle/base/core/web/WEB-INF/lib   # exists
    ls bundle/base/web/WEB-INF/lib        # does not exist