### PR TITLE
CLI: Load test README clarifies that post.json must be created.

### DIFF
--- a/netuno.cli/load-test/README.md
+++ b/netuno.cli/load-test/README.md
@@ -13,7 +13,11 @@ Useful for using with VisualVM to find leaks.
 
 ### POST
 
-Parameters are loaded in `post.json`.
+`post.sh` sends the request body from a `post.json` file (`ab -p post.json -T application/json`). That file is not included, so create it in this directory first, for example:
+
+```json
+{}
+```
 
 ```
 ./post.sh http://localhost:9000/services/my-service


### PR DESCRIPTION
## What

`netuno.cli/load-test/post.sh` runs `ab -p post.json -T application/json`, reading the request body from a `post.json` file that isn't included in the directory. The README says "Parameters are loaded in post.json" without telling the reader to create it. Add that step with a minimal example.

## How to verify

    cat netuno.cli/load-test/post.sh   # ab -p post.json ...
    ls netuno.cli/load-test/           # README.md, get.sh, post.sh — no post.json