### PR TITLE
README: supported languages list corrected to match the sandboxes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,14 @@ Documentation highlights:
 
 ![Application Architecture](https://raw.githubusercontent.com/netuno-org/platform/main/docs/images/app-architecture.png)
 
-Netuno is written in Java and runs in GraalVM to facilitate web application development, it currently suppports the following programming languages:
+Netuno is written in Java and runs in GraalVM to facilitate web application development. It currently supports the following programming languages:
 
-- [JavaScript/ES6](https://www.graalvm.org/javascript/)
-- [Groovy](https://groovy-lang.org)
+- [JavaScript/ES6 and TypeScript](https://www.graalvm.org/javascript/)
+- [Groovy](https://groovy.apache.org/)
 - [JRuby (Ruby)](https://www.jruby.org)
-- [Jython (Python)](https://www.jython.org)
+- [GraalPy (Python)](https://www.graalvm.org/python/)
 - [Kotlin](https://kotlinlang.org)
+- CajuScript
 
 > 😎 While you are programming you won't need to restart the server to compile the newly updated code.
 >


### PR DESCRIPTION
## What

Corrects the supported-languages list in the top-level `README.md` to match the registered language sandboxes:

- Replace **Jython** with **GraalPy** — Python runs on GraalVM, not Jython.
- Add **TypeScript** and **CajuScript**.
- Point the Groovy link at `groovy.apache.org`, the project's canonical home (Groovy is an Apache project). The older `groovy-lang.org` domain has also been intermittently unreachable in recent days.

## How to verify

The language sandboxes are annotated in `netuno.tritao/src/main/java/org/netuno/tritao/sandbox/`:

    GraalSandbox        js, cjs, mjs, py, ts
    CajuScriptSandbox   cj
    GroovySandbox       groovy
    JRubySandbox        rb
    KotlinSandbox       kts

`grep -rn "@ScriptSandbox" netuno.tritao/src/main/java/org/netuno/tritao/sandbox/`