### PR TITLE
Tritao: README supported languages and library docs link corrected.

### DIFF
--- a/netuno.tritao/README.md
+++ b/netuno.tritao/README.md
@@ -15,11 +15,12 @@ Databases supported:
 ### Languages
 
 Polyglot script execution support:
-- [JavaScript/ES6](https://www.graalvm.org/javascript/)
-- [Groovy](https://groovy-lang.org)
+- [JavaScript/ES6 and TypeScript](https://www.graalvm.org/javascript/)
+- [Groovy](https://groovy.apache.org/)
 - [JRuby (Ruby)](https://www.jruby.org)
-- [Jython (Python)](https://www.jython.org)
+- [GraalPy (Python)](https://www.graalvm.org/python/)
 - [Kotlin](https://kotlinlang.org)
+- CajuScript
 
 ### Resources Low-Code
 
@@ -37,4 +38,4 @@ Many programming resources supported, some to low-code integration with:
 - Database
 - Performance Monitor
 
-> Find more and detailed information in the [library documentation](https://doc.netuno.org/docs/en/library/overview/).
+> Find more detailed information in the [library documentation](https://doc.netuno.org/docs/library/overview/).


### PR DESCRIPTION
## What

Applies the same supported-languages correction to `netuno.tritao/README.md` (Jython → GraalPy, add TypeScript and CajuScript), matching the `@ScriptSandbox` annotations under `src/main/java/org/netuno/tritao/sandbox/`.

Point the Groovy link at `groovy.apache.org`, the project's canonical home (Groovy is an Apache project). The older `groovy-lang.org` domain has also been intermittently unreachable in recent days.

Also fixes the library-documentation link, which used the old locale path:
`/docs/en/library/overview/` → `/docs/library/overview/`.

## How to verify

    grep -rn "@ScriptSandbox" netuno.tritao/src/main/java/org/netuno/tritao/sandbox/