### PR TITLE
Bundle: Base app server README languages and default folders corrected.

### DIFF
--- a/bundle/base/apps/_/server/README.md
+++ b/bundle/base/apps/_/server/README.md
@@ -6,13 +6,15 @@ The polyglot scripting framework makes the REST API development easy and fast.
 
 The supported languages with their code file extensions are:
 
-- JavaScript`.js`
-- Python`.py`
-- Ruby`.rb`
-- Kotlin`.kts`
-- Groovy`.groovy`
+- JavaScript: `.js`, `.cjs`, `.mjs`
+- TypeScript: `.ts`
+- Python (GraalPy): `.py`
+- Ruby (JRuby): `.rb`
+- Kotlin: `.kts`
+- Groovy: `.groovy`
+- CajuScript: `.cj`
 
-The backend folders and their purpose are:
+The backend folders and their purpose are listed below. A new application ships with `core`, `services`, `setup`, and `templates`; the others (`actions`, `components`, `reports`) are optional and can be created when you need them.
 
 - `actions` - Injects code behavior in form and database modifications, more about [Actions](https://doc.netuno.org/docs/academy/server/actions).
 - `components` - Custom form fields and data structures.


### PR DESCRIPTION
## What

In `bundle/base/apps/_/server/README.md` (the new-app template):

- List the supported languages with their file extensions, matching the registered sandboxes: JavaScript (`.js`, `.cjs`, `.mjs`), TypeScript (`.ts`), Python/GraalPy (`.py`), Ruby/JRuby (`.rb`), Kotlin (`.kts`), Groovy (`.groovy`), CajuScript (`.cj`).
- Clarify that a new app ships with `core`, `services`, `setup`, `templates`; the `actions`, `components`, `reports` folders are optional and created on demand (they are not present by default).

## How to verify

Each extension comes from a `@ScriptSandbox` annotation in `netuno.tritao/src/main/java/org/netuno/tritao/sandbox/`:

| Extensions | Source |
| --- | --- |
| `js`, `cjs`, `mjs`, `py`, `ts` | `GraalSandbox.java:55` — `@ScriptSandbox(extensions = {"js", "cjs", "mjs", "py", "ts"})` |
| `rb` | `JRubySandbox.java:27` — `@ScriptSandbox(extensions = {"rb"})` |
| `kts` | `KotlinSandbox.java:29` — `@ScriptSandbox(extensions = {"kts"})` |
| `groovy` | `GroovySandbox.java:27` — `@ScriptSandbox(extensions = {"groovy"})` |
| `cj` | `CajuScriptSandbox.java:27` — `@ScriptSandbox(extensions = {"cj"})` |

    grep -rn "@ScriptSandbox" netuno.tritao/src/main/java/org/netuno/tritao/sandbox/
    ls bundle/base/apps/_/server/   # core, services, setup, templates