### PR TITLE
Bundle: App template and demo READMEs added.

### DIFF
--- a/bundle/base/apps/_/README.md
+++ b/bundle/base/apps/_/README.md
@@ -1,8 +1,6 @@
-# Application Template (`_`)
+# Application
 
-This directory (`_`) is the template used as the base for new applications on the Netuno Platform.
-
-When you create a new application with the Netuno CLI, this structure is copied to form the foundation of your new app.
+This is a Netuno Platform application.
 
 ## Structure Overview
 

--- a/bundle/base/apps/_/README.md
+++ b/bundle/base/apps/_/README.md
@@ -1,0 +1,16 @@
+# Application Template (`_`)
+
+This directory (`_`) is the template used as the base for new applications on the Netuno Platform.
+
+When you create a new application with the Netuno CLI, this structure is copied to form the foundation of your new app.
+
+## Structure Overview
+
+* **`config/`** — environment configuration files (`.json` and `.js`).
+* **`server/`** — the application backend: REST services, core scripts, database setup, and templates, written in the supported polyglot languages.
+* **`ui/`** — the back-office dashboard build environment (React, Ant Design, Vite).
+* **`public/`** — publicly accessible assets and files.
+* **`storage/`** — persistent file storage (for example, uploads).
+* **`dbs/`** — local file-based database files.
+
+See the `README.md` inside each directory for more detail.

--- a/bundle/base/apps/demo/README.md
+++ b/bundle/base/apps/demo/README.md
@@ -1,0 +1,14 @@
+# Demo Application
+
+The `demo` application ships with the Netuno Platform bundle as a working example of how a Netuno application is structured.
+
+It doubles as a reference and a ready-to-run sandbox, and it is the source cloned by the CLI's example commands (for example `app=demo`).
+
+## Structure Overview
+
+* **`config/`** — environment configuration files (`.json` and `.js`) for the demo.
+* **`server/`** — the demo backend: REST services, database setup, and templates.
+* **`ui/`** — the React back-office dashboard.
+* **`public/`** — public assets and entry points.
+* **`storage/`** — local storage used by the demo forms and file uploads.
+* **`dbs/`** — local file-based database files for the demo.


### PR DESCRIPTION
## What

`bundle/base/apps/_` (the new-app template) and `bundle/base/apps/demo` have no top-level README. This adds a short one to each, describing the shared folder layout: `config`, `server`, `ui`, `public`, `storage`, `dbs`.

**Note:** unlike the other slices, these are *new* documents rather than corrections to existing text — flagging that for review. No behavioral claims are made.

## How to verify

    ls bundle/base/apps/_/       # config, dbs, public, server, storage, ui
    ls bundle/base/apps/demo/    # config, dbs, public, server, storage, ui