### PR TITLE
Tritao: PDF extract adapted to the Tika 4.0.0 TikaInputStream requirement.

### DIFF
--- a/netuno.tritao/src/main/java/org/netuno/tritao/resource/pdf/PDFExtract.java
+++ b/netuno.tritao/src/main/java/org/netuno/tritao/resource/pdf/PDFExtract.java
@@ -17,6 +17,7 @@
 
 package org.netuno.tritao.resource.pdf;
 
+import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.pdf.PDFParser;
@@ -112,7 +113,9 @@ public interface PDFExtract {
         ParseContext pContext = new ParseContext();
 
         PDFParser pdfparser = new PDFParser();
-        pdfparser.parse(in, handler, metadata, pContext);
+        try (TikaInputStream tikaIn = TikaInputStream.get(in)) {
+            pdfparser.parse(tikaIn, handler, metadata, pContext);
+        }
 
         Values result = new Values();
         Values resultMetadata = new Values();

--- a/netuno.tritao/src/main/java/org/netuno/tritao/resource/pdf/PDFExtract.java
+++ b/netuno.tritao/src/main/java/org/netuno/tritao/resource/pdf/PDFExtract.java
@@ -17,6 +17,7 @@
 
 package org.netuno.tritao.resource.pdf;
 
+import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
 import org.apache.tika.parser.ParseContext;
 import org.apache.tika.parser.pdf.PDFParser;
@@ -112,7 +113,10 @@ public interface PDFExtract {
         ParseContext pContext = new ParseContext();
 
         PDFParser pdfparser = new PDFParser();
-        pdfparser.parse(in, handler, metadata, pContext);
+
+        try (TikaInputStream tikaIn = TikaInputStream.get(closeShield(in))) {
+            pdfparser.parse(tikaIn, handler, metadata, pContext);
+        }
 
         Values result = new Values();
         Values resultMetadata = new Values();
@@ -123,5 +127,12 @@ public interface PDFExtract {
         result.set("metadata", resultMetadata);
         result.set("content", handler.toString());
         return result;
+    }
+
+    private static java.io.InputStream closeShield(java.io.InputStream in) {
+        return new java.io.FilterInputStream(in) {
+            @Override
+            public void close() { }
+        };
     }
 }


### PR DESCRIPTION
The bump from Tika 3.3.1 to 4.0.0 narrowed PDFParser.parse to accept only
TikaInputStream, which was breaking the compilation of the PDF resource.

The stream received is now wrapped with TikaInputStream.get inside a
try-with-resources, so any temporary file that Tika creates is released
after the parsing. The wrapping goes through a close shield because
closing the TikaInputStream would also close the stream received, which
belongs to whoever called the extraction and stayed open before the bump.